### PR TITLE
added a vscode snippet to insert GPL license info

### DIFF
--- a/.vscode/license.code-snippets
+++ b/.vscode/license.code-snippets
@@ -1,0 +1,34 @@
+{
+	// Each snippet is defined under a snippet name and has a scope, prefix, body and 
+	// description. Add comma separated ids of the languages where the snippet is applicable in the scope field. If scope 
+	// is left empty or omitted, the snippet gets applied to all languages. The prefix is what is 
+	// used to trigger the snippet and the body will be expanded and inserted. Possible variables are: 
+	// $1, $2 for tab stops, $0 for the final cursor position, and ${1:label}, ${2:another} for placeholders. 
+	// Placeholders with the same ids are connected.
+
+	"gpl_license_header": {
+		"prefix": "gpl_add_head",
+		"body":[
+			"$LINE_COMMENT ${1:Program Name and Function}",
+			"$LINE_COMMENT Copyright (C) $CURRENT_YEAR OpenTrafficCam Contributors",
+			"$LINE_COMMENT <https://github.com/OpenTrafficCam",
+			"$LINE_COMMENT <team@opentrafficcam.org>",
+			"$LINE_COMMENT",
+			"$LINE_COMMENT This program is free software: you can redistribute it and/or modify",
+			"$LINE_COMMENT it under the terms of the GNU General Public License as published by",
+			"$LINE_COMMENT the Free Software Foundation, either version 3 of the License, or",
+			"$LINE_COMMENT (at your option) any later version.",
+			"$LINE_COMMENT",
+			"$LINE_COMMENT This program is distributed in the hope that it will be useful,",
+			"$LINE_COMMENT but WITHOUT ANY WARRANTY; without even the implied warranty of",
+			"$LINE_COMMENT MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the",
+			"$LINE_COMMENT GNU General Public License for more details.",
+			"$LINE_COMMENT",
+			"$LINE_COMMENT You should have received a copy of the GNU General Public License",
+			"$LINE_COMMENT along with this program.  If not, see <https://www.gnu.org/licenses/>.",
+			"",
+		],
+		"description": "Add GPLv3 license information in source code."
+	}
+
+}


### PR DESCRIPTION
I added a [VS Code Snippet](https://code.visualstudio.com/docs/editor/userdefinedsnippets) to insert the GPL license information at the current cursor position with just a breeze. 

Type `gpl_` and you should see 'gpl_add_head' in auto completion. Choose it to insert the license header. 

Provide a short Program Name and Function Description. You can use tab to jump to the end of the comment.

Definitely helpful, but should it be contained in the repository? (It is more a general decision to include the `.vscode` path in the repository or not.)

What's your opinion @martinbaerwolff ?