### PR TITLE
Fix time sync error causing existing log files being written to although a new log file should be created on every new run of OTCamera

### DIFF
--- a/OTCamera/hardware/button.py
+++ b/OTCamera/hardware/button.py
@@ -112,6 +112,14 @@ def _on_wifi_button_released() -> None:
         while timer <= config.WIFI_DELAY:
             if wifi_button.is_pressed:
                 break
+            # 💩-FIX to bypass single threaded gpiozero callback handler
+            elif not power_button.is_pressed:
+                _on_power_button_released()
+            elif hour_button.is_pressed():
+                status.hour_button_pressed = True
+            elif not hour_button.is_pressed():
+                status.hour_button_pressed = False
+
             sleep(1)
             timer += 1
         if not wifi_button.is_pressed:

--- a/OTCamera/hardware/button.py
+++ b/OTCamera/hardware/button.py
@@ -115,9 +115,9 @@ def _on_wifi_button_released() -> None:
             # 💩-FIX to bypass single threaded gpiozero callback handler
             elif not power_button.is_pressed:
                 _on_power_button_released()
-            elif hour_button.is_pressed():
+            elif hour_button.is_pressed:
                 status.hour_button_pressed = True
-            elif not hour_button.is_pressed():
+            elif not hour_button.is_pressed:
                 status.hour_button_pressed = False
 
             sleep(1)
@@ -125,6 +125,7 @@ def _on_wifi_button_released() -> None:
         if not wifi_button.is_pressed:
             rpi.wifi_switch_off()
         else:
+            status.wifi_button_pressed = True
             log.write("Wi-Fi not turned off. Button pressed again.")
             led.wifi_on()
 

--- a/raspi-files/otcamera.service
+++ b/raspi-files/otcamera.service
@@ -7,6 +7,7 @@ WorkingDirectory=/path/to/otcamera
 Restart=always
 RestartSec=3
 ExecStart=/usr/bin/python3 run.py
+Type=idle
 
 
 [Install]


### PR DESCRIPTION
Execute `otcamera.service` after all active jobs are dispatched

The problem is that the same log file is written on every boot
although it should be written to a new file depending on the timestamp.
It could be that after system reboot the otcamera.service is started
before the system time is synced with the RTC causing the system
to return the last saved time before the reboot.

Making the service start after clock synchronization should fix
this problem.

OP#633