### PR TITLE
Resolve race condition concerning wifi resource when trying to enable the wifistart script

### DIFF
--- a/raspi-files/otcamera.service
+++ b/raspi-files/otcamera.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=This service starts OTCamera and keeps it running
+After=rc-local.service
 
 [Service]
 User=username

--- a/raspi-files/usr/local/bin/wifistart
+++ b/raspi-files/usr/local/bin/wifistart
@@ -23,10 +23,12 @@ ifconfig uap0 up
 # Start hostapd. 
 echo "Starting hostapd service..."
 systemctl start hostapd.service
+sleep 10
 
 # Start dhcpcd. 
 echo "Starting dhcpcd service..."
 systemctl start dhcpcd.service
+sleep 5
 
 echo "Starting dnsmasq service..."
 systemctl start dnsmasq.service

--- a/raspi-files/usr/local/bin/wifistart
+++ b/raspi-files/usr/local/bin/wifistart
@@ -6,32 +6,30 @@ systemctl stop hostapd.service
 systemctl stop dnsmasq.service
 systemctl stop dhcpcd.service
 
-#Make sure no uap0 interface exists (this generates an error; we could probably use an if statement to check if it exists first)
+# Make sure no uap0 interface exists (this generates an error; we could probably use an if statement to check if it exists first)
 echo "Removing uap0 interface..."
 iw dev uap0 del
-
-rfkill unblock wlan
 sleep 5
 
-#Add uap0 interface (this is dependent on the wireless interface being called wlan0, which it may not be in Stretch)
+# Add uap0 interface (this is dependent on the wireless interface being called wlan0, which it may not be in Stretch)
 echo "Adding uap0 interface..."
+rfkill unblock wifi
 iw dev wlan0 interface add uap0 type __ap
 
 # Bring up uap0 interface. Commented out line may be a possible alternative to using dhcpcd.conf to set up the IP address.
 #ifconfig uap0 192.168.70.1 netmask 255.255.255.0 broadcast 192.168.70.255
 ifconfig uap0 up
 
-# Start hostapd. 10-second sleep avoids some race condition, apparently. It may not need to be that long. (?)
+# Start hostapd. 
 echo "Starting hostapd service..."
 systemctl start hostapd.service
-sleep 10
 
-#Start dhcpcd. Again, a 5-second sleep
+# Start dhcpcd. 
 echo "Starting dhcpcd service..."
 systemctl start dhcpcd.service
-sleep 5
 
 echo "Starting dnsmasq service..."
 systemctl start dnsmasq.service
-sbin/iw dev wlan0 set power_save off
+
+/sbin/iw dev wlan0 set power_save off
 echo "wifistart DONE"

--- a/raspi-files/usr/local/bin/wifistart
+++ b/raspi-files/usr/local/bin/wifistart
@@ -23,12 +23,12 @@ ifconfig uap0 up
 # Start hostapd. 
 echo "Starting hostapd service..."
 systemctl start hostapd.service
-sleep 10
+sleep 1 
 
 # Start dhcpcd. 
 echo "Starting dhcpcd service..."
 systemctl start dhcpcd.service
-sleep 5
+sleep 1 
 
 echo "Starting dnsmasq service..."
 systemctl start dnsmasq.service


### PR DESCRIPTION
Ensures that wifi network device is enabled for
the wifistart script  to be executed succesfully.
Furthermore the otcamera.service is configured
to start after the wiffistart has finished execution.

(OP#958)