### PR TITLE
fix fstab user permissions

### DIFF
--- a/raspi-files/install_otcamera.sh
+++ b/raspi-files/install_otcamera.sh
@@ -62,7 +62,7 @@ sed $RCLOCAL -i -e "/^exit 0/i /usr/bin/tvservice -o"
 echo "    Setting USB mount access permissions"
 FSTAB="/etc/fstab"
 cp $FSTAB $FSTAB.backup
-echo "/dev/sda1 /home/$SUDO_USER/mnt/usb auto noauto,uid=otc,gid=otc,umask=022 0 0" >> $FSTAB
+echo "/dev/sda1 /home/$SUDO_USER/mnt/usb auto user,noauto,uid=$SUDO_USER,gid=$SUDO_USER,umask=022 0 0" >> $FSTAB
 
 echo "#### Setting up OTCamera"
 


### PR DESCRIPTION
- `user` in fstab allows users without su rights to mount usb drives
- changed `uid` and `gid` to `$SUDO_USER` to be more generic