### PR TITLE
task/9683-remove-ms-teams-logging-handler

### DIFF
--- a/OTCamera/__main__.py
+++ b/OTCamera/__main__.py
@@ -242,10 +242,6 @@ class OTCamera:
                 StatusHtmlId.EXT_POWER_SUPPLY_CONNECTED,
                 self._power.external_power_connected,
             ),
-            ms_teams_webhook_enabled=(
-                StatusHtmlId.MS_TEAMS_WEBHOOK_ENABLED,
-                self._config.msteams.enable,
-            ),
             time_until_wifi_off=(StatusHtmlId.TIME_UNTIL_WIFI_OFF, time_until_wifi_off),
         )
 

--- a/OTCamera/config.py
+++ b/OTCamera/config.py
@@ -130,20 +130,6 @@ class HardwareConfig(BaseModel):
     use_adc: bool = False
 
 
-class MsTeamsConfig(BaseModel):
-    """MS Teams logging webhook settings."""
-
-    enable: bool = False
-    url: StrFromYaml | None = None
-    max_failed_send_attempts: int = 2
-
-    @model_validator(mode="after")
-    def _require_url_when_enabled(self) -> "MsTeamsConfig":
-        if self.enable and self.url is None:
-            raise ValueError("msteams.url is required when msteams.enable is true")
-        return self
-
-
 class AdcConfig(BaseModel):
     """Voltage thresholds used by power monitoring."""
 
@@ -192,7 +178,6 @@ class Config(BaseModel):
     video: VideoConfig = Field(default_factory=VideoConfig)
     wifi: WifiConfig = Field(default_factory=WifiConfig)
     hardware: HardwareConfig = Field(default_factory=HardwareConfig)
-    msteams: MsTeamsConfig = Field(default_factory=MsTeamsConfig)
     adc: AdcConfig = Field(default_factory=AdcConfig)
     ot_cloud: OTCloudSettings | None = None
     rabbitmq: RabbitMqConfig | None = None

--- a/OTCamera/html_updater.py
+++ b/OTCamera/html_updater.py
@@ -65,7 +65,6 @@ class StatusHtmlId(Enum):
     HOUR_BUTTON_ACTIVE = "24-7-recording"
     WIFI_AP_ON = "wifi-ap-on"
     EXT_POWER_SUPPLY_CONNECTED = "ext-power-supply-connected"
-    MS_TEAMS_WEBHOOK_ENABLED = "ms-teams-webhook-enabled"
     TIME_UNTIL_WIFI_OFF = "time-until-wifi-off"
 
 
@@ -145,7 +144,6 @@ class StatusDataObject(OTCameraDataObject):
     low_battery: Tuple[Enum, bool]
     hour_button_active: Tuple[Enum, bool]
     external_power_supply_connected: Tuple[Enum, bool]
-    ms_teams_webhook_enabled: Tuple[Enum, bool]
     time_until_wifi_off: Tuple[Enum, str]
 
 
@@ -196,7 +194,6 @@ STATUS_DESC = {
     StatusHtmlId.LOW_BATTERY: "Battery Low",
     StatusHtmlId.HOUR_BUTTON_ACTIVE: "24/7 Recording",
     StatusHtmlId.EXT_POWER_SUPPLY_CONNECTED: "External Power Supply Connected",
-    StatusHtmlId.MS_TEAMS_WEBHOOK_ENABLED: "MS Teams Webhook Enabled",
     StatusHtmlId.TIME_UNTIL_WIFI_OFF: "Turn Wi-Fi Off In",
 }
 """Dictionary that maps a StatusHtmlId to its description to be displayed on the status

--- a/OTCamera/log.py
+++ b/OTCamera/log.py
@@ -1,48 +1,10 @@
 """Logging setup for OTCamera."""
 
-import json
 import logging
 from datetime import datetime as dt
 from pathlib import Path
 
-import requests
-
 from OTCamera.config import Config
-
-
-class MsTeamsHandler(logging.Handler):
-    """Logging handler that posts log messages to an MS Teams webhook."""
-
-    def __init__(self, webhook_url: str, max_failures: int = 2) -> None:
-        super().__init__()
-        self._webhook_url = webhook_url
-        self._max_failures = max_failures
-        self._failed_attempts = 0
-        self._disabled = False
-
-    def emit(self, record: logging.LogRecord) -> None:
-        """Send one formatted log record to MS Teams."""
-        if self._disabled or record.levelno <= logging.DEBUG:
-            return
-
-        message = self.format(record)
-        try:
-            response = requests.post(
-                self._webhook_url,
-                headers={"Content-Type": "application/json"},
-                data=json.dumps({"text": message}),
-                timeout=10,
-            )
-        except requests.exceptions.RequestException:
-            self._failed_attempts += 1
-        else:
-            if 400 <= response.status_code < 600:
-                self._failed_attempts += 1
-            else:
-                self._failed_attempts = 0
-
-        if self._failed_attempts >= self._max_failures:
-            self._disabled = True
 
 
 def setup_logging(config: Config) -> None:
@@ -67,14 +29,6 @@ def setup_logging(config: Config) -> None:
     stream_handler = logging.StreamHandler()
     stream_handler.setFormatter(formatter)
     root_logger.addHandler(stream_handler)
-
-    if config.msteams.enable and config.msteams.url:
-        teams_handler = MsTeamsHandler(
-            webhook_url=config.msteams.url,
-            max_failures=config.msteams.max_failed_send_attempts,
-        )
-        teams_handler.setFormatter(formatter)
-        root_logger.addHandler(teams_handler)
 
 
 def _log_file_path(config: Config) -> Path:

--- a/tests/html_updater_test.py
+++ b/tests/html_updater_test.py
@@ -82,7 +82,6 @@ def status_data() -> StatusDataObject:
             StatusHtmlId.EXT_POWER_SUPPLY_CONNECTED,
             True,
         ),
-        ms_teams_webhook_enabled=(StatusHtmlId.MS_TEAMS_WEBHOOK_ENABLED, False),
         time_until_wifi_off=(StatusHtmlId.TIME_UNTIL_WIFI_OFF, "300s"),
     )
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,9 +1,6 @@
 import textwrap
 from pathlib import Path
 
-import pytest
-from pydantic import ValidationError
-
 from OTCamera.config import Config, parse_user_config
 
 
@@ -55,9 +52,6 @@ def test_parse_user_config_minimal(tmp_path: Path) -> None:
               use_leds: true
               use_buttons: true
               use_adc: true
-            msteams:
-              enable: false
-              url: ""
             adc:
               threshold_external_power: 2.5
               threshold_low_battery: 3.3
@@ -107,8 +101,3 @@ def test_default_config_has_sensible_values() -> None:
     assert config.hardware.use_leds is False
     assert config.hardware.use_buttons is False
     assert config.hardware.use_adc is False
-
-
-def test_msteams_requires_url_when_enabled() -> None:
-    with pytest.raises(ValidationError, match="url"):
-        Config.model_validate({"msteams": {"enable": True}})

--- a/tests/test_user_config.yaml
+++ b/tests/test_user_config.yaml
@@ -59,11 +59,6 @@ hardware:
   use_buttons: buttons
   use_adc: adc
 
-msteams:
-  enable: msteams
-  url: url
-  max_failed_send_attempts: max_failed_send_attempts
-
 adc:
   threshold_external_power: threshold_external_power
   threshold_low_battery: threshold_low_battery

--- a/user_config.example.yaml
+++ b/user_config.example.yaml
@@ -121,11 +121,6 @@ hardware:
   use_buttons: false
   use_adc: false
 
-msteams:
-  enable: false
-  url: null
-  max_failed_send_attempts: 2
-
 adc:
   threshold_external_power: 2.5
   threshold_low_battery: 3.3

--- a/user_config.yaml
+++ b/user_config.yaml
@@ -91,11 +91,6 @@ hardware:
 wifi:
   delay: 900
 
-msteams:
-  enable: false
-  url: null
-  max_failed_send_attempts: 2
-
 adc:
   threshold_external_power: 2.5
   threshold_low_battery: 3.3


### PR DESCRIPTION
The MS teams logging handler is deprecated. This PR removes it.

OP#9683