### PR TITLE
docs: add plans/agents conventions and archive completed v2 plans

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,54 @@
+# Issue tracker: Local Markdown
+
+Specs (you may know a spec as a PRD) and their implementation issues live as markdown
+files in `docs/plans/`. They are **tracked and committed** — a spec should survive, be
+reviewable in a pull request, and be present in any `git worktree` you create.
+
+`.scratch/` is gitignored and remains available for genuinely throwaway working state.
+Do not put specs there.
+
+## Conventions
+
+- One feature per directory: `docs/plans/<feature-slug>/`, where the slug matches the
+  tracker issue and the branch name, e.g. `10125-low-battery-recognition-based-on-aggregated-voltage-thresholds`
+- The spec is `docs/plans/<feature-slug>/spec.md`
+- Implementation issues are one file per ticket at
+  `docs/plans/<feature-slug>/issues/<NN>-<slug>.md`, numbered from `01` — never a single
+  combined tickets file
+- Triage state is recorded as a `Status:` line near the top of each file (see
+  `triage-labels.md` for the role strings)
+- Comments and conversation history append to the bottom of the file under a
+  `## Comments` heading
+- When work completes, move the directory to `docs/plans/archive/` and add a banner to
+  the spec marking it historical. See `docs/plans/README.md`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a new file under `docs/plans/<feature-slug>/` (creating the directory if needed).
+
+## When a skill says "fetch the relevant ticket"
+
+Read the file at the referenced path. The user will normally pass the path or the issue
+number directly.
+
+## Searching
+
+`docs/plans/archive/` holds completed plans containing large embedded code listings, and
+is the biggest source of false matches in this repo. When searching for a code symbol,
+scope to `OTCamera/` and `tests/`, or exclude the archive:
+
+```bash
+rg '<symbol>' --glob '!docs/plans/archive/**'
+```
+
+## Wayfinding operations
+
+Used by `/wayfinder`. These are ephemeral coordination files, not specs, so they stay in
+the gitignored `.scratch/`. The **map** is a file with one **child** file per ticket.
+
+- **Map**: `.scratch/<effort>/map.md` — the Notes / Decisions-so-far / Fog body.
+- **Child ticket**: `.scratch/<effort>/issues/NN-<slug>.md`, numbered from `01`, with the question in the body. A `Type:` line records the ticket type (`research`/`prototype`/`grilling`/`task`); a `Status:` line records `claimed`/`resolved`.
+- **Blocking**: a `Blocked by: NN, NN` line near the top. A ticket is unblocked when every file it lists is `resolved`.
+- **Frontier**: scan `.scratch/<effort>/issues/` for files that are open, unblocked, and unclaimed; first by number wins.
+- **Claim**: set `Status: claimed` and save before any work.
+- **Resolve**: append the answer under an `## Answer` heading, set `Status: resolved`, then append a context pointer (gist + link) to the map's Decisions-so-far in `map.md`.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -1,0 +1,39 @@
+# Plans
+
+Specs for planned and in-progress work. One directory per feature, named after its
+tracker issue:
+
+```
+docs/plans/
+├── README.md
+├── <issue>-<slug>/
+│   ├── spec.md              ← the spec, with a Status: line near the top
+│   └── issues/NN-<slug>.md  ← implementation tickets, if the spec is split up
+└── archive/                 ← completed work, kept for its reasoning only
+```
+
+`Status:` values come from [../agents/triage-labels.md](../agents/triage-labels.md).
+The vocabulary a spec uses is defined in [../../CONTEXT.md](../../CONTEXT.md), and
+decisions worth preserving beyond a single spec live in [../adr/](../adr/).
+
+These files are committed. They are tracked rather than kept in `.scratch/` so that a
+spec survives, is reviewable in a pull request, and is present in a `git worktree` — a
+gitignored spec is absent from every worktree you create.
+
+## archive/
+
+Completed work. **Nothing in `archive/` describes current intent**, and nothing there
+should be executed. Each archived file carries a banner saying so, because the realistic
+way an agent meets these documents is a grep landing mid-file, not a reader starting at
+the top.
+
+Be aware when searching: `archive/2026-03-27-v2-architecture-refactor-plan.md` is ~4,400
+lines of embedded code listings, which makes it the largest source of false matches in
+this repo. When searching for a symbol, prefer scoping to `OTCamera/` and `tests/`, or
+exclude this directory:
+
+```bash
+rg 'is_low_battery' --glob '!docs/plans/archive/**'
+```
+
+When work completes, move its directory here and add a banner to the spec.

--- a/docs/plans/archive/2026-03-05-v2-architecture-refactor-design.md
+++ b/docs/plans/archive/2026-03-05-v2-architecture-refactor-design.md
@@ -1,9 +1,16 @@
 # OTCamera v2 Architecture Refactor — Design
 
+> **ARCHIVED — historical record, not current intent.**
+> This design was implemented. The code under `OTCamera/` is now the authority on the v2
+> architecture, and this document is kept only for the reasoning behind the layering.
+> Its code listings are stale in places; do not copy from them and do not treat them as
+> the current shape of any module. Specifically, the battery handling it describes was
+> superseded by [ADR-0001](../../adr/0001-spread-battery-voltage-sampling.md).
+
 **Date:** 2026-03-05
 **Updated:** 2026-03-27 (consolidated with hardware layer separation amendment, applied learnings from first implementation attempt, design review refinements)
 **Branch:** `v2-refactor` (from `v2`)
-**Status:** Approved
+**Status:** Implemented — superseded by the code
 
 ## Context
 

--- a/docs/plans/archive/2026-03-27-v2-architecture-refactor-plan.md
+++ b/docs/plans/archive/2026-03-27-v2-architecture-refactor-plan.md
@@ -1,6 +1,14 @@
 # v2 Architecture Refactor — Implementation Plan
 
-> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **ARCHIVED — completed work, not current intent. Do not execute this plan.**
+> Every step here was carried out; the code under `OTCamera/` is the authority. This file
+> is 4,400 lines of embedded code listings from before and during the refactor, so it is
+> the single largest source of false matches when searching this repo — if a grep for a
+> symbol lands you here, you are reading history, not code.
+>
+> The instruction that used to sit in this spot told agents to use the
+> `superpowers:subagent-driven-development` skill. That framework is no longer in use;
+> see `docs/agents/` for the current conventions. Follow those instead.
 
 **Goal:** Refactor OTCamera into clean layers (domain / bsl / module / plugin / controller) with a hybrid event bus, hardware ABCs, board support layer, and provider pattern for swappable components.
 
@@ -8,7 +16,7 @@
 
 **Tech Stack:** Python >=3.11, gpiozero, picamera2, smbus2, psutil, pyyaml, beautifulsoup4, pytest
 
-**Design doc:** `docs/plans/2026-03-05-v2-architecture-refactor-design.md`
+**Design doc:** `docs/plans/archive/2026-03-05-v2-architecture-refactor-design.md`
 
 ---
 


### PR DESCRIPTION
Introduce docs/plans/README.md describing where specs and plans live and how completed ones are archived, and docs/agents/issue-tracker.md describing the issue-tracker workflow agents should follow.

Move the two finished v2 architecture refactor documents into docs/plans/archive/ per that convention.

Split out of the 10125 branch, where these process docs were unrelated to the low-battery change they travelled with.