### PR TITLE
make s3 upload more idiomatic

### DIFF
--- a/OTCamera/plugin/upload/exceptions.py
+++ b/OTCamera/plugin/upload/exceptions.py
@@ -8,7 +8,33 @@ class UploadError(OTCameraError):
 
 
 class FileUploadError(UploadError):
-    """Raised when uploading a specific file fails."""
+    """Raised when uploading a specific file fails.
+
+    All upload failures are retried the same way, no matter why they failed.
+    The optional fields below do not change what happens; they are there to
+    describe the cause of the failure in the log.
+
+    Attributes:
+        error_code: Backend-specific failure code, when the backend reports one.
+        status_code: HTTP status code, when the backend reports one.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        error_code: str | None = None,
+        status_code: int | None = None,
+    ) -> None:
+        """Initialize a new `FileUploadError`.
+
+        Args:
+            message (str): Human-readable description of the failure.
+            error_code (str | None): Backend-specific failure code, if known.
+            status_code (int | None): HTTP status code, if known.
+        """
+        super().__init__(message)
+        self.error_code = error_code
+        self.status_code = status_code
 
 
 class BackendUnavailableError(UploadError):

--- a/OTCamera/plugin/upload/s3_upload.py
+++ b/OTCamera/plugin/upload/s3_upload.py
@@ -2,7 +2,6 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from boto3.s3.transfer import TransferConfig
 from botocore.exceptions import ClientError
 
 from OTCamera.domain.upload import S3UploadResult, Upload
@@ -11,25 +10,33 @@ from OTCamera.plugin.upload.exceptions import FileUploadError
 logger = logging.getLogger(__name__)
 
 
-# Disable boto3-internal split and threading, let us handle concurrency
-TRANSFER_CONFIG = TransferConfig(
-    multipart_threshold=100
-    * 1024
-    * 1024
-    * 1024,  # effectively disable multipart (100GB)
-    max_concurrency=1,  # no internal threads
-    use_threads=False,
-)
+def _read_client_error_details(error: ClientError) -> tuple[str | None, int | None]:
+    """Read the error code and HTTP status out of a boto3 `ClientError`.
+
+    Both parts can be absent, for example when the request never reached the
+    server, so neither is assumed to be present.
+
+    Args:
+        error (ClientError): The exception raised by boto3.
+
+    Returns:
+        tuple[str | None, int | None]: The error code and HTTP status, each None
+            when the response did not carry it.
+    """
+    response = error.response or {}
+    error_code = response.get("Error", {}).get("Code")
+    status_code = response.get("ResponseMetadata", {}).get("HTTPStatusCode")
+    return error_code, status_code
 
 
 class S3Upload(Upload):
     """Upload files to an S3-compatible object storage.
 
     Thread-safe: each call to `upload` is independent and uses no shared
-    mutable state beyond the boto3 client, which is itself thread-safe for
-    concurrent `upload_file` calls.  Internal boto3 multipart splitting and
-    its own threading are disabled via `TRANSFER_CONFIG` so that concurrency
-    is controlled entirely by the caller.
+    mutable state beyond the boto3 client, which is itself thread-safe.
+    Each file is sent as one single PUT request, so there is no internal
+    splitting or threading and concurrency is controlled entirely by the
+    caller.
     """
 
     def __init__(
@@ -55,25 +62,44 @@ class S3Upload(Upload):
         """Upload a single file to the configured S3 bucket.
 
         The file is stored under the key ``{key_prefix}/{filename}`` when a
-        prefix is set, or just ``{filename}`` otherwise.
+        prefix is set, or just ``{filename}`` otherwise. It is sent as one
+        single PUT request, so a refusal from the server surfaces directly
+        with its error code and HTTP status.
+
+        The failure is described in the raised error rather than logged here:
+        the caller retries and is the one place that knows how often it has
+        already tried.
 
         Args:
             file_path: Path to the local file to upload.
-        """
-        try:
-            name = Path(file_path).name
-            key = f"{self.key_prefix}/{name}" if self.key_prefix else name
 
-            self.client.upload_file(
-                file_path, self.bucket_name, key, Config=TRANSFER_CONFIG
-            )
-            logger.info("Uploaded %s", name)
-            return S3UploadResult(
-                local_path=file_path, bucket=self.bucket_name, key=key
-            )
+        Returns:
+            S3UploadResult: Where the file was stored.
+
+        Raises:
+            FileUploadError: If the upload did not complete, carrying the
+                backend's error code and HTTP status when it reported them.
+        """
+        name = Path(file_path).name
+        key = f"{self.key_prefix}/{name}" if self.key_prefix else name
+
+        try:
+            with open(file_path, "rb") as body:
+                self.client.put_object(Bucket=self.bucket_name, Key=key, Body=body)
+        except ClientError as e:
+            error_code, status_code = _read_client_error_details(e)
+            raise FileUploadError(
+                f"S3 refused: {error_code} ({status_code})",
+                error_code=error_code,
+                status_code=status_code,
+            ) from e
+        except OSError as e:
+            raise FileUploadError(f"Could not read {name}: {e}") from e
         except Exception as e:
-            logger.error("Unexpected error during S3 upload: %s", e)
             raise FileUploadError(f"Could not upload to S3 bucket. Error: {e}") from e
+
+        logger.info("Uploaded %s", name)
+        return S3UploadResult(local_path=file_path, bucket=self.bucket_name, key=key)
 
     def is_available(self) -> bool:
         """Perform a quick check to confirm that we are ready to upload files."""

--- a/tests/plugin/upload/test_s3_upload.py
+++ b/tests/plugin/upload/test_s3_upload.py
@@ -1,0 +1,108 @@
+from pathlib import Path
+from typing import Any
+
+import boto3
+import pytest
+from botocore.exceptions import ClientError
+from botocore.stub import Stubber
+
+from OTCamera.plugin.upload.exceptions import FileUploadError
+from OTCamera.plugin.upload.s3_upload import S3Upload
+
+
+class FakeS3Client:
+    """An S3 client whose `put_object` raises a configured exception."""
+
+    def __init__(self, error: Exception) -> None:
+        self._error = error
+
+    def put_object(self, *args: Any, **kwargs: Any) -> None:
+        raise self._error
+
+
+def _client_error(code: str, status: int) -> ClientError:
+    response: Any = {
+        "Error": {"Code": code, "Message": "denied"},
+        "ResponseMetadata": {"HTTPStatusCode": status},
+    }
+    return ClientError(response, "PutObject")
+
+
+def test_refusal_from_a_real_client_carries_the_error_code(tmp_path: Path) -> None:
+    """A refusal must reach `upload` as a `ClientError`, not wrapped.
+
+    boto3's `upload_file` wraps refusals in `S3UploadFailedError`, which
+    hides the error code. This test runs against a real client so a change
+    back to a wrapping transfer method fails here, not in the field.
+    """
+    video = tmp_path / "video.h264"
+    video.write_bytes(b"x")
+    client = boto3.client(
+        "s3",
+        region_name="eu-central-1",
+        aws_access_key_id="testing",
+        aws_secret_access_key="testing",
+    )
+    stubber = Stubber(client)
+    stubber.add_client_error(
+        "put_object",
+        service_error_code="AccessDenied",
+        service_message="denied",
+        http_status_code=403,
+    )
+    upload = S3Upload(client, "bucket")
+
+    with stubber, pytest.raises(FileUploadError) as exc_info:
+        upload.upload(video)
+
+    assert exc_info.value.error_code == "AccessDenied"
+    assert exc_info.value.status_code == 403
+
+
+def test_client_error_surfaces_boto_error_code(tmp_path: Path) -> None:
+    video = tmp_path / "video.h264"
+    video.write_bytes(b"x")
+    upload = S3Upload(FakeS3Client(_client_error("AccessDenied", 403)), "bucket")
+
+    with pytest.raises(FileUploadError) as exc_info:
+        upload.upload(video)
+
+    assert exc_info.value.error_code == "AccessDenied"
+    assert exc_info.value.status_code == 403
+
+
+def test_client_error_without_details_leaves_fields_none(tmp_path: Path) -> None:
+    video = tmp_path / "video.h264"
+    video.write_bytes(b"x")
+    error = ClientError({}, "PutObject")
+    upload = S3Upload(FakeS3Client(error), "bucket")
+
+    with pytest.raises(FileUploadError) as exc_info:
+        upload.upload(video)
+
+    assert exc_info.value.error_code is None
+    assert exc_info.value.status_code is None
+
+
+def test_os_error_reports_the_unreadable_file(tmp_path: Path) -> None:
+    video = tmp_path / "video.h264"
+    video.write_bytes(b"x")
+    upload = S3Upload(FakeS3Client(OSError("input/output error")), "bucket")
+
+    with pytest.raises(FileUploadError) as exc_info:
+        upload.upload(video)
+
+    assert "video.h264" in str(exc_info.value)
+    assert exc_info.value.error_code is None
+
+
+def test_unexpected_error_carries_no_error_code(tmp_path: Path) -> None:
+    video = tmp_path / "video.h264"
+    video.write_bytes(b"x")
+    upload = S3Upload(FakeS3Client(RuntimeError("boom")), "bucket")
+
+    with pytest.raises(FileUploadError) as exc_info:
+        upload.upload(video)
+
+    assert exc_info.value.error_code is None
+    assert exc_info.value.status_code is None


### PR DESCRIPTION
Originally part of 9781, this was extracted as a standalone change as it is more of a cosmetic improvment, not a functional change.

The current implementation uses a workaround to circumvent the automated multi-part handling (manipulating the transfer config). Using `put_object` is the more natural choice as it uses the s3 API directly without internal multi-part handling (https://stackoverflow.com/questions/43739415/what-is-the-difference-between-file-upload-and-put-object-when-uploading-fil)