### PR TITLE
task/9781-backlog

### DIFF
--- a/OTCamera/controller/backlog.py
+++ b/OTCamera/controller/backlog.py
@@ -1,6 +1,7 @@
 """The on-disk store of recorded segments that are waiting to be uploaded."""
 
 import logging
+import os
 import re
 from datetime import datetime as dt
 from pathlib import Path
@@ -104,10 +105,10 @@ class Backlog:
         timestamp sorts behind every name that has one, so a stray file is
         uploaded last and never blocks the segments behind it.
         """
-        segments = self._segments()
-        if not segments:
+        names = self._segment_names()
+        if not names:
             return None
-        return min(segments, key=_sort_key)
+        return self._pending / min(names, key=_sort_key)
 
     def remove(self, segment: Path) -> None:
         """Delete a segment from the backlog.
@@ -122,7 +123,7 @@ class Backlog:
 
     def size(self) -> int:
         """Return how many segments are waiting to be uploaded."""
-        return len(self._segments())
+        return len(self._segment_names())
 
     def free_bytes(self) -> int:
         """Return the free space on the filesystem holding the segments."""
@@ -141,7 +142,7 @@ class Backlog:
         oldest = self.oldest()
         if oldest is None:
             return None
-        timestamp = _timestamp_of(oldest)
+        timestamp = _timestamp_of(oldest.name)
         if timestamp is None:
             return None
         return (dt.now() - timestamp).total_seconds()
@@ -168,9 +169,14 @@ class Backlog:
             recovered += 1
         return recovered
 
-    def _segments(self) -> list[Path]:
-        """Return the files currently in the backlog, in no particular order."""
-        return [path for path in self._pending.iterdir() if path.is_file()]
+    def _segment_names(self) -> list[str]:
+        """Return the names of the segments in the backlog, in no order.
+
+        Only the directory listing is read, never the files themselves, so
+        counting the backlog stays cheap as it grows.
+        """
+        with os.scandir(self._pending) as entries:
+            return [entry.name for entry in entries if entry.is_file()]
 
     def count_uploaded(self) -> None:
         """Record that a segment reached the server."""
@@ -181,16 +187,16 @@ class Backlog:
         self._dropped_total += 1
 
 
-def _timestamp_of(segment: Path) -> dt | None:
+def _timestamp_of(name: str) -> dt | None:
     """Return the timestamp encoded in a segment's filename, if it has one.
 
     Args:
-        segment (Path): The segment whose name should be parsed.
+        name (str): The filename to parse, without its directory.
 
     Returns:
         dt | None: The timestamp, or None when the name does not carry one.
     """
-    match = _TIMESTAMP_PATTERN.search(segment.stem)
+    match = _TIMESTAMP_PATTERN.search(name)
     if match is None:
         return None
     try:
@@ -199,17 +205,17 @@ def _timestamp_of(segment: Path) -> dt | None:
         return None
 
 
-def _sort_key(segment: Path) -> tuple[int, dt | str]:
+def _sort_key(name: str) -> tuple[int, dt | str]:
     """Return an oldest-first sort key that tolerates unparseable names.
 
     Args:
-        segment (Path): The segment to build a key for.
+        name (str): The filename to build a key for.
 
     Returns:
         tuple[int, dt | str]: A key that sorts every timestamped name before
             every name without a timestamp.
     """
-    timestamp = _timestamp_of(segment)
+    timestamp = _timestamp_of(name)
     if timestamp is None:
-        return (1, segment.name)
+        return (1, name)
     return (0, timestamp)

--- a/OTCamera/controller/backlog.py
+++ b/OTCamera/controller/backlog.py
@@ -1,0 +1,215 @@
+"""The on-disk store of recorded segments that are waiting to be uploaded."""
+
+import logging
+import re
+from datetime import datetime as dt
+from pathlib import Path
+
+import psutil
+
+logger = logging.getLogger(__name__)
+
+_PENDING_DIR_NAME = "pending"
+_TIMESTAMP_PATTERN = re.compile(r"_(\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2})")
+_TIMESTAMP_FORMAT = "%Y-%m-%d_%H-%M-%S"
+
+
+class Backlog:
+    """The recorded segments that are not on the server yet.
+
+    The backlog is a plain directory, `<video_dir>/pending`. There is no index
+    and no sidecar file: a segment is in the backlog if it is in that
+    directory. Segments get there by being renamed, which only stays atomic
+    while both directories are on one filesystem; the constructor checks that.
+
+    Two threads use the backlog without a lock. The camera thread only adds,
+    and always the newest segment; the upload worker only removes, and always
+    the oldest. The two therefore never touch the same file.
+    """
+
+    def __init__(self, video_dir: Path, video_format: str, min_free_bytes: int) -> None:
+        """Create the backlog directory below `video_dir`.
+
+        Args:
+            video_dir (Path): Directory the camera records into.
+            video_format (str): Suffix of a recorded video file, e.g. `h264`.
+            min_free_bytes (int): Free space below which segments are dropped to
+                keep recording.
+
+        Raises:
+            ValueError: If the backlog directory turns out to be `video_dir`
+                itself, or to sit on a different filesystem.
+        """
+        self._video_dir = video_dir.expanduser().resolve()
+        self._video_format = video_format
+        self._min_free_bytes = min_free_bytes
+
+        pending = self._video_dir / _PENDING_DIR_NAME
+        pending.mkdir(parents=True, exist_ok=True)
+        self._pending = pending.resolve()
+
+        if self._pending == self._video_dir:
+            raise ValueError(
+                f"Backlog directory must differ from the video directory, "
+                f"both are {self._video_dir}"
+            )
+        if self._video_dir.stat().st_dev != self._pending.stat().st_dev:
+            raise ValueError(
+                f"Backlog directory {self._pending} must be on the same "
+                f"filesystem as {self._video_dir} so that moving a segment "
+                f"stays atomic"
+            )
+
+        self._uploaded_total = 0
+        self._dropped_total = 0
+
+    @property
+    def pending(self) -> Path:
+        """Return the directory holding the segments waiting to be uploaded."""
+        return self._pending
+
+    @property
+    def uploaded_total(self) -> int:
+        """Return how many segments have been uploaded since startup."""
+        return self._uploaded_total
+
+    @property
+    def dropped_total(self) -> int:
+        """Return how many segments have been dropped to reclaim space."""
+        return self._dropped_total
+
+    def add(self, segment: Path) -> Path:
+        """Accept a finished segment into the backlog and return its new path.
+
+        The segment keeps its name, because the name carries the timestamp the
+        backlog is ordered by. `recover_unfinished_segments` calls this at
+        startup; once recording has started only the camera thread may.
+
+        Args:
+            segment (Path): The finished video file in the video directory.
+
+        Returns:
+            Path: Where the segment now lives.
+        """
+        destination = self._pending / segment.name
+        segment.rename(destination)
+        logger.debug("Accepted %s into the backlog", destination.name)
+        return destination
+
+    def oldest(self) -> Path | None:
+        """Return the segment to upload next, or None when the backlog is empty.
+
+        Segments are ordered by the timestamp in the filename rather than by
+        file times, which a copy or a touch would change. A name without a
+        timestamp sorts behind every name that has one, so a stray file is
+        uploaded last and never blocks the segments behind it.
+        """
+        segments = self._segments()
+        if not segments:
+            return None
+        return min(segments, key=_sort_key)
+
+    def remove(self, segment: Path) -> None:
+        """Delete a segment from the backlog.
+
+        Only the upload worker may call this. A segment that is already gone is
+        not an error: the point is that it is no longer in the backlog.
+
+        Args:
+            segment (Path): The segment to delete.
+        """
+        segment.unlink(missing_ok=True)
+
+    def size(self) -> int:
+        """Return how many segments are waiting to be uploaded."""
+        return len(self._segments())
+
+    def free_bytes(self) -> int:
+        """Return the free space on the filesystem holding the segments."""
+        return int(psutil.disk_usage(str(self._video_dir)).free)
+
+    def is_below_floor(self) -> bool:
+        """Return whether space has to be reclaimed to keep recording."""
+        return self.free_bytes() <= self._min_free_bytes
+
+    def oldest_age_seconds(self) -> float | None:
+        """Return how long the oldest segment has waited, in seconds.
+
+        Returns None when the backlog is empty, or when the oldest segment
+        carries no timestamp to measure from.
+        """
+        oldest = self.oldest()
+        if oldest is None:
+            return None
+        timestamp = _timestamp_of(oldest)
+        if timestamp is None:
+            return None
+        return (dt.now() - timestamp).total_seconds()
+
+    def recover_unfinished_segments(self) -> int:
+        """Accept every video file left directly in the video directory.
+
+        This runs at startup, before recording begins, so anything still lying
+        in the video directory is from a recording that was cut short. Such a
+        segment is incomplete but holds footage, and how much footage depends on
+        the configured segment length, so it is uploaded rather than dropped.
+
+        The backlog is untouched, because the listing does not recurse, and so
+        are logs and the preview image, because only the video suffix is moved.
+
+        Returns:
+            int: How many files were moved into the backlog.
+        """
+        recovered = 0
+        for path in list(self._video_dir.iterdir()):
+            if not path.is_file() or path.suffix != f".{self._video_format}":
+                continue
+            self.add(path)
+            recovered += 1
+        return recovered
+
+    def _segments(self) -> list[Path]:
+        """Return the files currently in the backlog, in no particular order."""
+        return [path for path in self._pending.iterdir() if path.is_file()]
+
+    def count_uploaded(self) -> None:
+        """Record that a segment reached the server."""
+        self._uploaded_total += 1
+
+    def count_dropped(self) -> None:
+        """Record that a segment was deleted to reclaim space."""
+        self._dropped_total += 1
+
+
+def _timestamp_of(segment: Path) -> dt | None:
+    """Return the timestamp encoded in a segment's filename, if it has one.
+
+    Args:
+        segment (Path): The segment whose name should be parsed.
+
+    Returns:
+        dt | None: The timestamp, or None when the name does not carry one.
+    """
+    match = _TIMESTAMP_PATTERN.search(segment.stem)
+    if match is None:
+        return None
+    try:
+        return dt.strptime(match.group(1), _TIMESTAMP_FORMAT)
+    except ValueError:
+        return None
+
+
+def _sort_key(segment: Path) -> tuple[int, dt | str]:
+    """Return an oldest-first sort key that tolerates unparseable names.
+
+    Args:
+        segment (Path): The segment to build a key for.
+
+    Returns:
+        tuple[int, dt | str]: A key that sorts every timestamped name before
+            every name without a timestamp.
+    """
+    timestamp = _timestamp_of(segment)
+    if timestamp is None:
+        return (1, segment.name)
+    return (0, timestamp)

--- a/OTCamera/controller/backlog.py
+++ b/OTCamera/controller/backlog.py
@@ -12,7 +12,6 @@ logger = logging.getLogger(__name__)
 
 _PENDING_DIR_NAME = "pending"
 _TIMESTAMP_PATTERN = re.compile(r"_(\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2})")
-_TIMESTAMP_FORMAT = "%Y-%m-%d_%H-%M-%S"
 
 
 class Backlog:
@@ -190,6 +189,9 @@ class Backlog:
 def _timestamp_of(name: str) -> dt | None:
     """Return the timestamp encoded in a segment's filename, if it has one.
 
+    The fields are read from their fixed places in the name. A date that cannot
+    exist counts as no timestamp at all.
+
     Args:
         name (str): The filename to parse, without its directory.
 
@@ -199,8 +201,16 @@ def _timestamp_of(name: str) -> dt | None:
     match = _TIMESTAMP_PATTERN.search(name)
     if match is None:
         return None
+    stamp = match.group(1)
     try:
-        return dt.strptime(match.group(1), _TIMESTAMP_FORMAT)
+        return dt(
+            year=int(stamp[0:4]),
+            month=int(stamp[5:7]),
+            day=int(stamp[8:10]),
+            hour=int(stamp[11:13]),
+            minute=int(stamp[14:16]),
+            second=int(stamp[17:19]),
+        )
     except ValueError:
         return None
 

--- a/tests/controller/test_backlog.py
+++ b/tests/controller/test_backlog.py
@@ -101,6 +101,14 @@ class TestOldest:
 
         assert backlog.oldest() == timestamped
 
+    def test_a_date_that_cannot_exist_sorts_last(self, tmp_path: Path) -> None:
+        backlog = _backlog(tmp_path)
+        impossible = backlog.add(_segment(tmp_path, "2026-13-45_10-00-00"))
+        timestamped = backlog.add(_segment(tmp_path, "2026-08-12_10-00-00"))
+
+        assert backlog.oldest() == timestamped
+        assert backlog.oldest() != impossible
+
     def test_returns_a_stray_file_once_it_is_the_only_one(self, tmp_path: Path) -> None:
         backlog = _backlog(tmp_path)
         stray = tmp_path / "stray.h264"

--- a/tests/controller/test_backlog.py
+++ b/tests/controller/test_backlog.py
@@ -1,0 +1,258 @@
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from OTCamera.controller.backlog import Backlog
+
+_GIB = 1024 * 1024 * 1024
+
+
+def _backlog(video_dir: Path, min_free_bytes: int = 0) -> Backlog:
+    return Backlog(
+        video_dir=video_dir,
+        video_format="h264",
+        min_free_bytes=min_free_bytes,
+    )
+
+
+def _segment(video_dir: Path, timestamp: str, content: bytes = b"x") -> Path:
+    segment = video_dir / f"cam_FR20_{timestamp}.h264"
+    segment.write_bytes(content)
+    return segment
+
+
+class TestConstructor:
+    def test_creates_the_pending_directory(self, tmp_path: Path) -> None:
+        backlog = _backlog(tmp_path / "videos")
+
+        assert backlog.pending.is_dir()
+
+    def test_accepts_an_existing_pending_directory(self, tmp_path: Path) -> None:
+        (tmp_path / "pending").mkdir()
+
+        assert _backlog(tmp_path).pending == (tmp_path / "pending").resolve()
+
+    def test_rejects_a_pending_dir_that_is_the_video_dir_itself(
+        self, tmp_path: Path
+    ) -> None:
+        video_dir = tmp_path / "videos"
+        video_dir.mkdir()
+        (video_dir / "pending").symlink_to(video_dir, target_is_directory=True)
+
+        with pytest.raises(ValueError):
+            _backlog(video_dir)
+
+    def test_rejects_a_pending_dir_on_another_filesystem(self, tmp_path: Path) -> None:
+        devices = iter([SimpleNamespace(st_dev=1), SimpleNamespace(st_dev=2)])
+
+        with patch(
+            "OTCamera.controller.backlog.Path.stat",
+            side_effect=lambda *args, **kwargs: next(devices),
+        ):
+            with pytest.raises(ValueError):
+                _backlog(tmp_path)
+
+
+class TestAdd:
+    def test_moves_the_segment_into_pending(self, tmp_path: Path) -> None:
+        backlog = _backlog(tmp_path)
+        segment = _segment(tmp_path, "2026-08-12_10-00-00")
+
+        moved = backlog.add(segment)
+
+        assert moved == backlog.pending / segment.name
+        assert moved.is_file()
+        assert not segment.exists()
+
+    def test_leaves_nothing_behind_in_the_video_dir(self, tmp_path: Path) -> None:
+        backlog = _backlog(tmp_path)
+        backlog.add(_segment(tmp_path, "2026-08-12_10-00-00"))
+
+        assert [path.name for path in tmp_path.iterdir()] == ["pending"]
+
+    def test_keeps_the_segment_name_unchanged(self, tmp_path: Path) -> None:
+        backlog = _backlog(tmp_path)
+        segment = _segment(tmp_path, "2026-08-12_10-00-00")
+
+        assert backlog.add(segment).name == segment.name
+
+
+class TestOldest:
+    def test_is_none_on_an_empty_backlog(self, tmp_path: Path) -> None:
+        assert _backlog(tmp_path).oldest() is None
+
+    def test_orders_by_the_filename_timestamp_not_mtime(self, tmp_path: Path) -> None:
+        backlog = _backlog(tmp_path)
+        # Written newest-name-first, so an mtime-based implementation fails.
+        newest = backlog.add(_segment(tmp_path, "2026-08-12_12-00-00"))
+        oldest = backlog.add(_segment(tmp_path, "2026-08-12_10-00-00"))
+
+        assert backlog.oldest() == oldest
+        assert backlog.oldest() != newest
+
+    def test_a_name_without_a_timestamp_sorts_last(self, tmp_path: Path) -> None:
+        backlog = _backlog(tmp_path)
+        stray = tmp_path / "stray.h264"
+        stray.write_bytes(b"x")
+        backlog.add(stray)
+        timestamped = backlog.add(_segment(tmp_path, "2026-08-12_10-00-00"))
+
+        assert backlog.oldest() == timestamped
+
+    def test_returns_a_stray_file_once_it_is_the_only_one(self, tmp_path: Path) -> None:
+        backlog = _backlog(tmp_path)
+        stray = tmp_path / "stray.h264"
+        stray.write_bytes(b"x")
+        moved = backlog.add(stray)
+
+        assert backlog.oldest() == moved
+
+    def test_ignores_subdirectories_of_pending(self, tmp_path: Path) -> None:
+        backlog = _backlog(tmp_path)
+        (backlog.pending / "subdir").mkdir()
+
+        assert backlog.oldest() is None
+
+
+class TestRemove:
+    def test_deletes_the_segment(self, tmp_path: Path) -> None:
+        backlog = _backlog(tmp_path)
+        segment = backlog.add(_segment(tmp_path, "2026-08-12_10-00-00"))
+
+        backlog.remove(segment)
+
+        assert not segment.exists()
+
+    def test_does_not_raise_when_the_file_is_already_gone(self, tmp_path: Path) -> None:
+        backlog = _backlog(tmp_path)
+
+        backlog.remove(backlog.pending / "missing.h264")
+
+
+class TestSize:
+    def test_counts_the_segments_in_pending(self, tmp_path: Path) -> None:
+        backlog = _backlog(tmp_path)
+        backlog.add(_segment(tmp_path, "2026-08-12_10-00-00"))
+        backlog.add(_segment(tmp_path, "2026-08-12_11-00-00"))
+
+        assert backlog.size() == 2
+
+    def test_is_zero_on_an_empty_backlog(self, tmp_path: Path) -> None:
+        assert _backlog(tmp_path).size() == 0
+
+
+class TestFreeSpace:
+    def test_is_below_floor_when_free_space_is_at_the_floor(
+        self, tmp_path: Path
+    ) -> None:
+        backlog = _backlog(tmp_path, min_free_bytes=_GIB)
+
+        with patch(
+            "OTCamera.controller.backlog.psutil.disk_usage",
+            return_value=SimpleNamespace(free=_GIB),
+        ):
+            assert backlog.is_below_floor()
+
+    def test_is_not_below_floor_with_room_to_spare(self, tmp_path: Path) -> None:
+        backlog = _backlog(tmp_path, min_free_bytes=_GIB)
+
+        with patch(
+            "OTCamera.controller.backlog.psutil.disk_usage",
+            return_value=SimpleNamespace(free=_GIB + 1),
+        ):
+            assert not backlog.is_below_floor()
+
+    def test_free_bytes_reports_the_filesystem(self, tmp_path: Path) -> None:
+        backlog = _backlog(tmp_path)
+
+        with patch(
+            "OTCamera.controller.backlog.psutil.disk_usage",
+            return_value=SimpleNamespace(free=42),
+        ):
+            assert backlog.free_bytes() == 42
+
+
+class TestOldestAgeSeconds:
+    def test_is_none_on_an_empty_backlog(self, tmp_path: Path) -> None:
+        assert _backlog(tmp_path).oldest_age_seconds() is None
+
+    def test_is_none_when_the_oldest_name_carries_no_timestamp(
+        self, tmp_path: Path
+    ) -> None:
+        backlog = _backlog(tmp_path)
+        stray = tmp_path / "stray.h264"
+        stray.write_bytes(b"x")
+        backlog.add(stray)
+
+        assert backlog.oldest_age_seconds() is None
+
+    def test_grows_with_the_age_of_the_oldest_segment(self, tmp_path: Path) -> None:
+        backlog = _backlog(tmp_path)
+        backlog.add(_segment(tmp_path, "2020-01-01_00-00-00"))
+        backlog.add(_segment(tmp_path, "2026-08-12_10-00-00"))
+
+        age = backlog.oldest_age_seconds()
+
+        assert age is not None
+        assert age > 5 * 365 * 24 * 3600
+
+
+class TestRecoverUnfinishedSegments:
+    def test_moves_video_files_from_the_video_dir_into_the_backlog(
+        self, tmp_path: Path
+    ) -> None:
+        backlog = _backlog(tmp_path)
+        first = _segment(tmp_path, "2026-08-12_10-00-00")
+        second = _segment(tmp_path, "2026-08-12_10-15-00")
+
+        assert backlog.recover_unfinished_segments() == 2
+        assert not first.exists()
+        assert not second.exists()
+        assert (backlog.pending / first.name).is_file()
+        assert (backlog.pending / second.name).is_file()
+
+    def test_keeps_the_content_of_a_recovered_segment(self, tmp_path: Path) -> None:
+        backlog = _backlog(tmp_path)
+        cut_short = _segment(tmp_path, "2026-08-12_10-00-00", content=b"half a video")
+
+        backlog.recover_unfinished_segments()
+
+        assert (backlog.pending / cut_short.name).read_bytes() == b"half a video"
+
+    def test_leaves_the_backlog_logs_and_preview_alone(self, tmp_path: Path) -> None:
+        backlog = _backlog(tmp_path)
+        pending_segment = backlog.add(_segment(tmp_path, "2026-08-12_09-00-00"))
+        log_file = tmp_path / "otcamera_2026-08-12_10-00-00.log"
+        log_file.write_text("log")
+        preview = tmp_path / "preview.jpg"
+        preview.write_bytes(b"jpg")
+        _segment(tmp_path, "2026-08-12_10-15-00")
+
+        assert backlog.recover_unfinished_segments() == 1
+        assert pending_segment.is_file()
+        assert log_file.is_file()
+        assert preview.is_file()
+        assert backlog.size() == 2
+
+    def test_is_zero_when_the_video_dir_holds_no_segments(self, tmp_path: Path) -> None:
+        assert _backlog(tmp_path).recover_unfinished_segments() == 0
+
+
+class TestCounters:
+    def test_start_at_zero(self, tmp_path: Path) -> None:
+        backlog = _backlog(tmp_path)
+
+        assert backlog.uploaded_total == 0
+        assert backlog.dropped_total == 0
+
+    def test_count_uploads_and_drops(self, tmp_path: Path) -> None:
+        backlog = _backlog(tmp_path)
+
+        backlog.count_uploaded()
+        backlog.count_dropped()
+        backlog.count_dropped()
+
+        assert backlog.uploaded_total == 1
+        assert backlog.dropped_total == 2


### PR DESCRIPTION
OP#9781

This PR adds a `Backlog` class as part of the overarching task to create a persistent upload queue for S3.

The class abstracts away the file-level access, enabling better testability.

Performance improvements made by #190 have been ported over.